### PR TITLE
Got FileList to work with MediaWiki 1.33+

### DIFF
--- a/FileList.php
+++ b/FileList.php
@@ -15,6 +15,12 @@
 
 if (!defined('MEDIAWIKI')) die("Mediawiki not set");
 
+	
+/********** NAMESPACE USED **********/
+use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\Revision\SlotRecord;
+use MediaWiki\MediaWikiServices;
+
 /****************** EXTENSION ACTIONS ******************/
 $wgExtensionMessagesFiles[ 'FileList' ] = __DIR__ . '/FileList.i18n.php';
 
@@ -208,8 +214,8 @@ class FileList {
      * Sets a parser hook for <filelist/>.
      */
     public function __construct() {
-        global $wgParser;
-        $wgParser->setHook('filelist', array(&$this, 'hookML'));
+        MediaWikiServices::getInstance()->getParser()->setHook('filelist', array(&$this, 'hookML'));	    
+ 
     } // end of constructor
 
     /**
@@ -312,9 +318,9 @@ class FileList {
         $descr_column = false;
         foreach ($filelist as $dataobject) {
             $article = new Article ( Title::newFromText( 'File:'.$dataobject->img_name ) );
-            $revision = $article->getRevision();
+            $revision = $article->fetchRevisionRecord();
             if ($revision !== null) {
-                $content = $revision->getContent( Revision::RAW );
+                $content = $revision->getContent( SlotRecord::MAIN );
                 $descr = ContentHandler::getContentText( $content );
                 if(trim($descr) != "") {
                     $descr_column = true;
@@ -352,7 +358,7 @@ class FileList {
                 $img_name_w_underscores = substr($dataobject->img_name, strlen($prefix));
                 $link = $extension_folder_url . 'file.php?name='.urlencode($img_name_w_underscores) . "&file=" . urlencode($dataobject->img_name);
                 // if description exists, use this as filename
-                $descr = $dataobject->img_description;
+                $descr = $dataobject->img_description_id;
                 if($descr)
                     $img_name = $descr;
                 $output .= '<a href="'.htmlspecialchars($link).'">'.htmlspecialchars($img_name).'</a></td>';
@@ -378,7 +384,7 @@ class FileList {
                 
                 // USERNAME
                 if(!$wgFileListConfig['upload_anonymously']) {
-                    $output .= '<td>'.htmlspecialchars($dataobject->img_user_text).'</td>';
+                    $output .= '<td>'.htmlspecialchars($dataobject->img_actor).'</td>';
                 }
                 
                 // EDIT AND DELETE

--- a/library.php
+++ b/library.php
@@ -210,10 +210,10 @@ function fl_file_get_extension($filepath) {
  */
 function fl_list_files_of_page($pagename) {
     // Query the database.
-    $dbr = wfGetDB(DB_SLAVE);
+    $dbr = wfGetDB(DB_REPLICA);
     $res = $dbr->select(
         array('image'),
-        array('img_name','img_media_type','img_user_text','img_description', 'img_size',
+        array('img_name','img_media_type','img_actor','img_description_id', 'img_size',
               'img_timestamp','img_major_mime','img_minor_mime'),
         '',
         '',


### PR DESCRIPTION
 The install to LocalSettings.php is the same older method for now. I modified two files.
I tested viewing Filelist, adding file(s) to FileList and removing files(s) from FileList. 
One of the icons on the view file still does not work and causes problems. The other 
one does remove the file and can remove all files. These changes on the most part get
 the extension working without a problem,but still could use some modernization with
 loading the extension. Using it on spotcheckit.org currently. 

File:  library.php : Replaced DB_SLAVE to DB_REPLICA. Matched database select to match new columns img_actor and img_description_id.

File: FileList.php :Added namespace items and replaced $wgParser with MediaWikiServices::getInstance. Replaced getRevision with fetchRevisionRecord. Replaced Revision::RAW with SlotRecord::Main. Replaced $dataobject with new databases column changes.
